### PR TITLE
Resolvendo erro no ng test incluindo declaração do TestComponent

### DIFF
--- a/_04_diretivas/src/app/app.component.spec.ts
+++ b/_04_diretivas/src/app/app.component.spec.ts
@@ -3,11 +3,14 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
+import { TesteComponent } from './teste/teste.component';
+
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent
+        AppComponent,
+        TesteComponent
       ],
     });
   });

--- a/_04_diretivas/src/app/environments/environment.prod.ts
+++ b/_04_diretivas/src/app/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/_04_diretivas/src/app/environments/environment.ts
+++ b/_04_diretivas/src/app/environments/environment.ts
@@ -1,0 +1,8 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `angular-cli.json`.
+
+export const environment = {
+  production: false
+};


### PR DESCRIPTION
Resolvendo erro no ng test incluindo na declaração dos testes do app.component o TestComponent para poder gerar o componente com sucesso.